### PR TITLE
Remove unnecessary migration stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,3 @@ venv/
 
 # database
 *.db
-migrations/

--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,18 @@ install:
 	pip install -r requirements.txt; \
 	python manage.py initialize_database
 
+install-windows:
+	virtualenv venv; \
+	. venv/Scripts/activate.bat; \
+	pip install -r requirements.txt; \
+	python manage.py initialize_database
 
 run:
 	. venv/bin/activate; \
+	python manage.py run
+
+run-windows:
+	. venv/Scripts/activate.bat; \
 	python manage.py run
 
 all: clean install run

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,7 @@ install:
 	virtualenv venv; \
 	. venv/bin/activate; \
 	pip install -r requirements.txt; \
-	python manage.py db init; \
-	python manage.py db migrate --message 'initial database migration'; \
-	python manage.py db upgrade
+	python manage.py initialize_database
 
 
 run:

--- a/api/config.py
+++ b/api/config.py
@@ -10,6 +10,7 @@ class Config:
 class DevConfig(Config):
     DEBUG = True
     SQLALCHEMY_DATABASE_URI = 'sqlite:///' + os.path.join(basedir, 'environmental_codefest.db')
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
 
 
 class TestConfig(Config):

--- a/manage.py
+++ b/manage.py
@@ -1,7 +1,6 @@
 import os
 
 from flask_script import Manager
-from flask_migrate import Migrate, MigrateCommand
 
 from api import create_app, db
 
@@ -10,10 +9,10 @@ app = create_app(os.getenv("ENV", "dev"))
 
 manager = Manager(app)
 
-migrate = Migrate(app, db)
-
-manager.add_command('db', MigrateCommand)
-
+@manager.command
+def initialize_database():
+    from api.models.issue import Issue
+    db.create_all()
 
 @manager.command
 def run():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 Flask==1.1.2
-Flask-Migrate==2.5.3
 flask-restx==0.2.0
 Flask-Script==2.0.6
 Flask-SQLAlchemy==2.4.4


### PR DESCRIPTION
flask-migration is too complex and I don't think we need it - we're probably only going to have like 2 tables max and not that much data for the hackathon demo.

I just use db.create_all() to setup the tables.